### PR TITLE
Allow using hooks in React component decorators (like `React.memo`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Latest
+
+- Allow using hooks inside React component decorators, such as `React.memo` or `React.forwardRef`.
+
+  For example, the following code sample now **does not** violate the rule:
+
+  ```tsx
+  const MyComponent = React.memo(props => {
+    useEffect(() => {
+      console.log('Counter changed');
+    }, [props.value]);
+
+    return <div>Counter: {props.value}</div>;
+  });
+  ```
+
 ## v1.0.1 (2019-02-03)
 
 - Updated README

--- a/src/react-hooks-nesting-walker/is-binary-conditional-expression.ts
+++ b/src/react-hooks-nesting-walker/is-binary-conditional-expression.ts
@@ -17,5 +17,5 @@ export function isBinaryConditionalExpression(
     return false;
   }
 
-  return binaryConditionalOperators.indexOf(node.operatorToken.kind) !== -1;
+  return binaryConditionalOperators.includes(node.operatorToken.kind);
 }

--- a/src/react-hooks-nesting-walker/is-hook-call.ts
+++ b/src/react-hooks-nesting-walker/is-hook-call.ts
@@ -1,31 +1,17 @@
-import {
-  CallExpression,
-  isPropertyAccessExpression,
-  isIdentifier
-} from 'typescript';
+import { CallExpression } from 'typescript';
 
 import { isHookIdentifier } from './is-hook-identifier';
+import { isReactApiExpression } from './is-react-api-expression';
 
 /**
- * Tests is a `CallExpression` calls a React Hook
+ * Tests if a `CallExpression` calls a React Hook
  * @see https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L26
  */
 export function isHookCall({ expression }: CallExpression) {
-  if (isIdentifier(expression)) {
-    /**
-     * Test for direct `useHook` calls
-     */
-    return isHookIdentifier(expression);
-  } else if (isPropertyAccessExpression(expression)) {
-    /**
-     * Test for `React.useHook` calls
-     */
-    return (
-      isIdentifier(expression.expression) &&
-      expression.expression.text === 'React' &&
-      isHookIdentifier(expression.name)
-    );
-  }
-
-  return false;
+  return isHookAccessExpression(expression);
 }
+
+/**
+ * Tests for `useHook` or `React.useHook` calls
+ */
+const isHookAccessExpression = isReactApiExpression(isHookIdentifier);

--- a/src/react-hooks-nesting-walker/is-react-api-expression.ts
+++ b/src/react-hooks-nesting-walker/is-react-api-expression.ts
@@ -1,0 +1,35 @@
+import {
+  Identifier,
+  isPropertyAccessExpression,
+  isIdentifier,
+  Expression,
+} from 'typescript';
+
+export type Predicate<T> = (t: T) => boolean;
+
+/**
+ * Tests whether an `Expression` is an identifier that matches a predicate. Accepts also property
+ * access of that identifier from React's top-level API.
+ *
+ * @example
+ * const isForwardRef = isReactApiExpression((identifier) => identifier.text === 'forwardRef');
+ * // would match `isForwardRef` or `React.isForwardRef`
+ * const matches = isForwardRef(node);
+ *
+ * @param predicate Predicate that is run on the actual identifier.
+ */
+export const isReactApiExpression = (predicate: Predicate<Identifier>) => (
+  expression: Expression,
+) => {
+  if (isIdentifier(expression)) {
+    return predicate(expression);
+  } else if (isPropertyAccessExpression(expression)) {
+    return (
+      isIdentifier(expression.expression) &&
+      expression.expression.text === 'React' &&
+      predicate(expression.name)
+    );
+  }
+
+  return false;
+};

--- a/src/react-hooks-nesting-walker/is-react-component-decorator.ts
+++ b/src/react-hooks-nesting-walker/is-react-component-decorator.ts
@@ -1,0 +1,11 @@
+import { isReactApiExpression } from './is-react-api-expression';
+
+const reactComponentDecorators = ['forwardRef', 'memo'];
+
+/**
+ * Tests is an expression is a React top-level API component decorator (e.g. `React.forwardRef`,
+ * `React.memo`)
+ */
+export const isReactComponentDecorator = isReactApiExpression(identifier =>
+  reactComponentDecorators.includes(identifier.text),
+);

--- a/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
+++ b/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
@@ -14,13 +14,13 @@ import {
   isSourceFile,
   isClassDeclaration,
   isCallExpression,
-  isPropertyAccessExpression,
 } from 'typescript';
 
 import { isHookCall } from './is-hook-call';
 import { ERROR_MESSAGES } from './error-messages';
 import { isBinaryConditionalExpression } from './is-binary-conditional-expression';
 import { isComponentOrHookIdentifier } from './is-component-or-hook-identifier';
+import { isReactComponentDecorator } from './is-react-component-decorator';
 
 export class ReactHooksNestingWalker extends RuleWalker {
   public visitCallExpression(node: CallExpression) {
@@ -113,20 +113,11 @@ export class ReactHooksNestingWalker extends RuleWalker {
       /**
        * Allow using hooks when the function is passed to `React.memo` or `React.forwardRef`
        */
-      if (isCallExpression(ancestor.parent)) {
-        if (
-          isIdentifier(ancestor.parent.expression) &&
-          ['memo', 'forwardRef'].includes(ancestor.parent.expression.text)
-        ) {
-          return;
-        } else if (
-          isPropertyAccessExpression(ancestor.parent.expression) &&
-          isIdentifier(ancestor.parent.expression.expression) &&
-          ancestor.parent.expression.expression.text === 'React' &&
-          ['memo', 'forwardRef'].includes(ancestor.parent.expression.name.text)
-        ) {
-          return;
-        }
+      if (
+        isCallExpression(ancestor.parent) &&
+        isReactComponentDecorator(ancestor.parent.expression)
+      ) {
+        return;
       }
 
       // Disallow using hooks inside other kinds of functions

--- a/test/tslint-rule/react-top-level-api.ts.lint
+++ b/test/tslint-rule/react-top-level-api.ts.lint
@@ -1,0 +1,36 @@
+// Tests for React top level APIs that wrap components
+
+import React, { memo, forwardRef } from 'react';
+
+// Hooks should be allowed inside functions passed to React.memo and React.forwardRef
+
+const MemoizedComponent = React.memo(() => {
+  const ref = useRef();
+
+  return <div>Memoized</div>;
+});
+
+const RefForwardingComponent = React.forwardRef((props, ref) => {
+  useEffect(() => {
+    console.log('Forwarding refs');
+  });
+
+  return <div ref={ref}>Forwarding refs</div>;
+});
+
+
+// The same as above, but not using the `React` prefix
+
+const MemoizedComponent = memo(() => {
+  const ref = useRef();
+
+  return <div>Memoized</div>;
+});
+
+const RefForwardingComponent = forwardRef((props, ref) => {
+  useEffect(() => {
+    console.log('Forwarding refs');
+  });
+
+  return <div ref={ref}>Forwarding refs</div>;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "strict": true,
-    "target": "es2015"
+    "target": "es2015",
+    "lib": ["esnext"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Fixes #2 

I added an exception that allows using hooks in function expressions passed to `React.memo` and `React.forwardRef`. As far as I know, these are all React top-level APIs that should allow hooks.

## Implementation details

Whenever a parent of a hook call is a function expression (either an anonymous function or an arrow function), the rule checks whether the parent of that function expression is a call expression to `forwardRef` or `memo` (possibly prefixed by `React.`).

I noticed that same `React.` prefix has to be handled when detecting whether a call expression is a React hook, becuase a native React hook can be called by either `useState` or `React.useState`.

I came up with a function (`isReactApiExpression`) that allows for easy matching identifiers that could be prefixed by the `React` identifier.