### PR TITLE
Fix detecting hooks uses after early return

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The rule is based on an [ESLint plugin for react hooks](https://github.com/faceb
   - ternary expressions
   - loops (`while`, `for`, `do ... while`)
   - functions that themselves are not custom hooks or components
+- detects using React hooks in spite of an early return
 
 ## Installation
 

--- a/src/react-hooks-nesting-walker/error-messages.ts
+++ b/src/react-hooks-nesting-walker/error-messages.ts
@@ -16,4 +16,5 @@ export const ERROR_MESSAGES = {
   invalidFunctionDeclaration:
     'A hook cannot be used inside of another function',
   invalidFunctionExpression: 'A hook cannot be used inside of another function',
+  hookAfterEarlyReturn: 'A hook should not appear after a return statement',
 };

--- a/src/react-hooks-nesting-walker/find-parent-function.ts
+++ b/src/react-hooks-nesting-walker/find-parent-function.ts
@@ -1,0 +1,14 @@
+import { Node } from 'typescript';
+import { FunctionNode, isFunctionNode } from './function-node';
+
+export function findParentFunction(node: Node): FunctionNode | null {
+  if (isFunctionNode(node)) {
+    return node;
+  }
+
+  if (!node.parent) {
+    return null;
+  }
+
+  return findParentFunction(node.parent);
+}

--- a/src/react-hooks-nesting-walker/function-node.ts
+++ b/src/react-hooks-nesting-walker/function-node.ts
@@ -1,0 +1,20 @@
+import {
+  FunctionDeclaration,
+  FunctionExpression,
+  ArrowFunction,
+  Node,
+  isFunctionDeclaration,
+  isFunctionExpression,
+  isArrowFunction,
+} from 'typescript';
+
+export type FunctionNode =
+  | FunctionDeclaration
+  | FunctionExpression
+  | ArrowFunction;
+
+const matchers = [isFunctionDeclaration, isFunctionExpression, isArrowFunction];
+
+export function isFunctionNode(node: Node): node is FunctionNode {
+  return matchers.some(matcher => matcher(node));
+}

--- a/test/tslint-rule/early-return.ts.lint
+++ b/test/tslint-rule/early-return.ts.lint
@@ -1,0 +1,21 @@
+function MyComponent() {
+  const [counter, setCounter] = useState(0);
+
+  if (counter > 5) {
+    return <div>Counter is over 5</div>;
+  }
+
+  useEffect(() => {
+  ~~~~~~~~~~~~~~~~~
+    console.log('Counter is', counter);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  });
+~~~~ [A hook should not appear after a return statement]
+
+  return (
+    <div>
+      {counter} -
+      <button onClick={() => setCounter(counter + 1)}>+1</button>
+    </div>
+  );
+}

--- a/test/tslint-rule/early-return.ts.lint
+++ b/test/tslint-rule/early-return.ts.lint
@@ -19,3 +19,12 @@ function MyComponent() {
     </div>
   );
 }
+
+function useCustomHook(param: number) {
+  if (param > 5) {
+    return 'a';
+  }
+
+  useEffect(() => { });
+  ~~~~~~~~~~~~~~~~~~~~ [A hook should not appear after a return statement]
+}


### PR DESCRIPTION
This PR adds reporting rule violations whenever a hook appears after a return statement.

This should fix #1.

After this PR gets merged to `develop`, I will release a `2.0.0-alpha.1` version of the rule for developers to verify that it works and has no bugs. After a few days, I am going to release a `2.0.0` version of the rule.

## How this feature works?

Whenever a return statement is encountered, the parent function/method is found and stored in a set of functions that have a return statement.

https://github.com/Gelio/tslint-react-hooks/blob/c545a51c467bbceb1b2d366f791226f924048cb5/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts#L39-L47

Upon encountering a hook call, the parent function is found. If it already contains a return statement, a rule violation is reported (because the parent function - a hook or a component - may return early):

https://github.com/Gelio/tslint-react-hooks/blob/c545a51c467bbceb1b2d366f791226f924048cb5/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts#L97-L99

I am not proud of how the code is structured right now. The lengthy `visitHookAncestor` method hurts my eyes the most. I have an idea on how to refactor it, but first I would like to get early hooks detection out of the way.