### PR TITLE
Allow using hooks inside named function expressions

### DIFF
--- a/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
+++ b/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
@@ -133,6 +133,10 @@ export class ReactHooksNestingWalker extends RuleWalker {
        * const MyComponent = function() {
        *   useEffect();
        * }
+       *
+       * const MyComponent = function MyComponent() {
+       *   useEffect();
+       * }
        * ```
        */
 
@@ -155,6 +159,16 @@ export class ReactHooksNestingWalker extends RuleWalker {
         }
       }
 
+      /**
+       * Detect using hooks inside named function expressions
+       */
+      if (ancestor.name && isComponentOrHookIdentifier(ancestor.name)) {
+        return;
+      }
+
+      /**
+       * Detect that an unnamed function expression is a component or a hook
+       */
       if (
         isVariableDeclaration(ancestor.parent) &&
         isIdentifier(ancestor.parent.name) &&

--- a/test/tslint-rule/named-funciton-expressions.ts.lint
+++ b/test/tslint-rule/named-funciton-expressions.ts.lint
@@ -1,0 +1,9 @@
+const withHoc = <TProps extends object>(Component: ComponentType<TProps>) =>
+  function WrappedComponent(props: TProps) {
+    const [state] = useState();
+    return <Component {...props} />;
+  };
+
+const NamedComponent = function NamedComponent(props) {
+  const [state, setstate] = useState(initialState);
+};


### PR DESCRIPTION
Provides a workaround for #13 

Function expressions were not detected in all cases.

Consider the following snippet:

```tsx
const withHoc = <TProps extends object>(Component: ComponentType<TProps>) =>
  function WrappedComponent(props: TProps) {
    const [state] = useState();
    return <Component {...props} />;
  };
```

Before this PR the function expression would not be detected as a component and a rule violation for `useState` would be reported. This PR fixes that problem.