### PR TITLE
Allow detecting hooks from all namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.2.0 (2019-07-14)
+
+- Add support for optionally detecting hook calls from sources other than the `React` namespace
+  (e.g. `MyHooks.useHook`).
+
+  Usage is described in the README.
+
 ## v2.1.1 (2019-06-09)
 
 - Update dependencies due to security vulnerabilities

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The rule is based on an [ESLint plugin for react hooks](https://github.com/faceb
   - loops (`while`, `for`, `do ... while`)
   - functions that themselves are not custom hooks or components
 - detects using React hooks in spite of an early return
+- support for detecting hooks from namespaces other than `React` (e.g. `MyHooks.useHook`) (**optional**)
 
 ## Installation
 
@@ -47,6 +48,37 @@ Then, enable the rule by modifying `tslint.json`:
 ```
 
 To use report rule violations as warnings intead of errors, set it to `"warning"`.
+
+## Options
+
+While the rule works fine out-of-the-box, it can be customized. To specify options, use the
+following syntax when modifying `tslint.json`:
+
+```js
+{
+  "extends": [
+    // your other plugins...
+    "tslint-react-hooks"
+  ],
+  "rules": {
+    // your other rules...
+    "react-hooks-nesting": ["error", {
+      // options go here
+    }]
+  }
+}
+```
+
+### Available options
+
+- `"detect-hooks-from-non-react-namespace"` - when set to `true`, violations will be also reported
+  hooks accessed from sources other than the `React` namespace (e.g. `MyHooks.useHook` will be
+  treated as a hook).
+
+  By default, only direct calls (e.g. `useHook`) or calls from `React` namespace (e.g.
+  `React.useState`) are treated as hooks.
+
+Have an idea for an option? [Create a new issue](https://github.com/Gelio/tslint-react-hooks/issues/new).
 
 ## Workarounds
 

--- a/src/react-hooks-nesting-walker/is-hook-call.ts
+++ b/src/react-hooks-nesting-walker/is-hook-call.ts
@@ -1,17 +1,46 @@
-import { CallExpression } from 'typescript';
+import {
+  CallExpression,
+  isIdentifier,
+  isPropertyAccessExpression,
+  Expression,
+} from 'typescript';
 
 import { isHookIdentifier } from './is-hook-identifier';
-import { isReactApiExpression } from './is-react-api-expression';
+import {
+  RuleOptions,
+  detectHooksFromNonReactNamespaceOptionName,
+} from './options';
 
 /**
  * Tests if a `CallExpression` calls a React Hook
  * @see https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L26
  */
-export function isHookCall({ expression }: CallExpression) {
-  return isHookAccessExpression(expression);
+export function isHookCall(
+  { expression }: CallExpression,
+  ruleOptions: RuleOptions,
+) {
+  if (isIdentifier(expression) && isHookIdentifier(expression)) {
+    return true;
+  } else if (
+    isPropertyAccessExpression(expression) &&
+    isHookIdentifier(expression.name)
+  ) {
+    if (ruleOptions[detectHooksFromNonReactNamespaceOptionName]) {
+      return true;
+    }
+
+    /**
+     * The expression from which the property is accessed.
+     *
+     * @example for `React.useState`, this would be the `React` identifier
+     */
+    const sourceExpression = expression.expression;
+
+    return isReactIdentifier(sourceExpression);
+  }
+
+  return false;
 }
 
-/**
- * Tests for `useHook` or `React.useHook` calls
- */
-const isHookAccessExpression = isReactApiExpression(isHookIdentifier);
+const isReactIdentifier = (expression: Expression) =>
+  isIdentifier(expression) && expression.text === 'React';

--- a/src/react-hooks-nesting-walker/options.ts
+++ b/src/react-hooks-nesting-walker/options.ts
@@ -1,0 +1,35 @@
+export const detectHooksFromNonReactNamespaceOptionName =
+  'detect-hooks-from-non-react-namespace';
+
+export interface RuleOptions {
+  /**
+   * When set to `true`, violations will be reported for hooks from  namespaces other than `React
+   * (e.g. `MyHooks.useHook` will be treated as a hook).
+   */
+  [detectHooksFromNonReactNamespaceOptionName]?: boolean;
+}
+
+const defaultRuleOptions: RuleOptions = {};
+
+export function parseRuleOptions(rawOptionsArray: unknown): RuleOptions {
+  if (!Array.isArray(rawOptionsArray)) {
+    return defaultRuleOptions;
+  }
+
+  const rawOptions: Record<string, unknown> | undefined = rawOptionsArray[0];
+  if (!rawOptions) {
+    return defaultRuleOptions;
+  }
+
+  let parsedOptions: RuleOptions = { ...defaultRuleOptions };
+
+  const detectHooksFromNonReactNamespaceOption =
+    rawOptions[detectHooksFromNonReactNamespaceOptionName];
+  if (typeof detectHooksFromNonReactNamespaceOption === 'boolean') {
+    parsedOptions[
+      detectHooksFromNonReactNamespaceOptionName
+    ] = detectHooksFromNonReactNamespaceOption;
+  }
+
+  return parsedOptions;
+}

--- a/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
+++ b/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
@@ -26,12 +26,15 @@ import { isReactComponentDecorator } from './is-react-component-decorator';
 import { findAncestorFunction } from './find-ancestor-function';
 import { FunctionNode, isFunctionNode } from './function-node';
 import { findClosestAncestorNode } from './find-closest-ancestor-node';
+import { parseRuleOptions } from './options';
 
 export class ReactHooksNestingWalker extends RuleWalker {
   private functionsWithReturnStatements = new Set<FunctionNode>();
 
+  private readonly ruleOptions = parseRuleOptions(this.getOptions());
+
   public visitCallExpression(node: CallExpression) {
-    if (isHookCall(node)) {
+    if (isHookCall(node, this.ruleOptions)) {
       this.visitHookAncestor(node, node.parent);
     }
 

--- a/src/reactHooksNestingRule.ts
+++ b/src/reactHooksNestingRule.ts
@@ -1,7 +1,8 @@
 import { SourceFile } from 'typescript';
-import { Rules, IRuleMetadata } from 'tslint';
+import { Rules, IRuleMetadata, Utils } from 'tslint';
 
 import { ReactHooksNestingWalker } from './react-hooks-nesting-walker/react-hooks-nesting-walker';
+import { detectHooksFromNonReactNamespaceOptionName } from './react-hooks-nesting-walker/options';
 
 export class Rule extends Rules.AbstractRule {
   public static metadata: IRuleMetadata = {
@@ -9,9 +10,23 @@ export class Rule extends Rules.AbstractRule {
     description: 'Enforces Rules of Hooks',
     descriptionDetails: 'See https://reactjs.org/docs/hooks-rules.html',
 
-    optionsDescription: 'There are no available options.',
-    options: null,
-    optionExamples: [true],
+    optionsDescription: Utils.dedent`
+      An optional object with the property ${detectHooksFromNonReactNamespaceOptionName}.
+      When set to true, violations will be reported for hooks from namespaces other
+      than the React namespace (e.g. \`MyHooks.useHook\` will be treated as a hook).
+    `,
+    options: {
+      type: 'object',
+      properties: {
+        [detectHooksFromNonReactNamespaceOptionName]: {
+          type: 'boolean',
+        },
+      },
+    },
+    optionExamples: [
+      true,
+      [true, { [detectHooksFromNonReactNamespaceOptionName]: true }],
+    ],
 
     hasFix: false,
     type: 'functionality',

--- a/test/hooks-from-non-react-namespaces/non-react-namespaces.ts.lint
+++ b/test/hooks-from-non-react-namespaces/non-react-namespaces.ts.lint
@@ -1,0 +1,16 @@
+import * as MyHooks from './my-hooks';
+import MyHooks2 from './my-hooks-2';
+import { MyHooks3 } from './my-hooks-3';
+
+function MyComponent() {
+  if (true) {
+    MyHooks.useHook();
+    ~~~~~~~~~~~~~~~~~ [A hook cannot appear inside an if statement]
+
+    MyHooks2.useHook();
+    ~~~~~~~~~~~~~~~~~~ [A hook cannot appear inside an if statement]
+
+    MyHooks3.useHook();
+    ~~~~~~~~~~~~~~~~~~ [A hook cannot appear inside an if statement]
+  }
+}

--- a/test/hooks-from-non-react-namespaces/react-namespace.ts.lint
+++ b/test/hooks-from-non-react-namespaces/react-namespace.ts.lint
@@ -1,0 +1,8 @@
+import React from 'react';
+
+function MyComponent() {
+  if (true) {
+    React.useState();
+    ~~~~~~~~~~~~~~~~ [A hook cannot appear inside an if statement]
+  }
+}

--- a/test/hooks-from-non-react-namespaces/tslint.json
+++ b/test/hooks-from-non-react-namespaces/tslint.json
@@ -1,0 +1,11 @@
+{
+  "rulesDirectory": "../../dist",
+  "rules": {
+    "react-hooks-nesting": [
+      true,
+      {
+        "detect-hooks-from-non-react-namespace": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds an option (`"detect-hooks-from-non-react-namespace"`) that changes the hook detection logic so that hooks from sources other than the `React` namespace (e.g. `MyHooks.useHook`) are treated as hook calls.

This means sometimes false-positives can be found, for example:

```ts
const textHelpers = {
  useDefaultText: () => 'Foo'
};

const MyComponent = (props) => {
  let text = props.text;

  if (!text) {
    text = textHelpers.useDefaultText();
  }

  return <div>{text}</div>;
}
```

These cases are rare, but still could exist, therefore the default behavior is the same as in [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) - only calls from the `React` namespace are treated as hooks.

Since this is the first option that this rule accepts, some code related to parsing options has also been added.

Fixes #22 
