### PR TITLE
New option: ignoredFunctions

### DIFF
--- a/src/react-hooks-nesting-walker/is-hook-call.ts
+++ b/src/react-hooks-nesting-walker/is-hook-call.ts
@@ -9,6 +9,7 @@ import { isHookIdentifier } from './is-hook-identifier';
 import {
   RuleOptions,
   detectHooksFromNonReactNamespaceOptionName,
+  ignoredFunctionsOptionName,
 } from './options';
 
 /**
@@ -20,11 +21,14 @@ export function isHookCall(
   ruleOptions: RuleOptions,
 ) {
   if (isIdentifier(expression) && isHookIdentifier(expression)) {
-    return true;
+    return !ruleOptions[ignoredFunctionsOptionName].has(expression.text);
   } else if (
     isPropertyAccessExpression(expression) &&
     isHookIdentifier(expression.name)
   ) {
+    if (ruleOptions[ignoredFunctionsOptionName].has(expression.name.text)) {
+      return false;
+    }
     if (ruleOptions[detectHooksFromNonReactNamespaceOptionName]) {
       return true;
     }

--- a/src/react-hooks-nesting-walker/is-hook-identifier.ts
+++ b/src/react-hooks-nesting-walker/is-hook-identifier.ts
@@ -1,6 +1,6 @@
 import { Identifier } from 'typescript';
 
-export function isHookIdentifier(node: Identifier) {
+export function isHookIdentifier(node: Identifier): node is Identifier {
   return isHookName(node.text);
 }
 

--- a/src/react-hooks-nesting-walker/options.ts
+++ b/src/react-hooks-nesting-walker/options.ts
@@ -1,5 +1,6 @@
 export const detectHooksFromNonReactNamespaceOptionName =
   'detect-hooks-from-non-react-namespace';
+export const ignoredFunctionsOptionName = 'ignored-functions';
 
 export interface RuleOptions {
   /**
@@ -7,9 +8,15 @@ export interface RuleOptions {
    * (e.g. `MyHooks.useHook` will be treated as a hook).
    */
   [detectHooksFromNonReactNamespaceOptionName]?: boolean;
+  /**
+   * Every function name listed here will never be treated as a hook.
+   */
+  [ignoredFunctionsOptionName]: ReadonlySet<string>;
 }
 
-const defaultRuleOptions: RuleOptions = {};
+const defaultRuleOptions: RuleOptions = {
+  [ignoredFunctionsOptionName]: new Set(),
+};
 
 export function parseRuleOptions(rawOptionsArray: unknown): RuleOptions {
   if (!Array.isArray(rawOptionsArray)) {
@@ -21,7 +28,7 @@ export function parseRuleOptions(rawOptionsArray: unknown): RuleOptions {
     return defaultRuleOptions;
   }
 
-  let parsedOptions: RuleOptions = { ...defaultRuleOptions };
+  const parsedOptions: RuleOptions = { ...defaultRuleOptions };
 
   const detectHooksFromNonReactNamespaceOption =
     rawOptions[detectHooksFromNonReactNamespaceOptionName];
@@ -29,6 +36,14 @@ export function parseRuleOptions(rawOptionsArray: unknown): RuleOptions {
     parsedOptions[
       detectHooksFromNonReactNamespaceOptionName
     ] = detectHooksFromNonReactNamespaceOption;
+  }
+
+  const ignoredFunctionsOption =
+    rawOptions[ignoredFunctionsOptionName];
+  if (Array.isArray(ignoredFunctionsOption) && ignoredFunctionsOption.length > 0) {
+    parsedOptions[
+      ignoredFunctionsOptionName
+    ] = new Set(ignoredFunctionsOption);
   }
 
   return parsedOptions;

--- a/src/reactHooksNestingRule.ts
+++ b/src/reactHooksNestingRule.ts
@@ -2,7 +2,10 @@ import { SourceFile } from 'typescript';
 import { Rules, IRuleMetadata, Utils } from 'tslint';
 
 import { ReactHooksNestingWalker } from './react-hooks-nesting-walker/react-hooks-nesting-walker';
-import { detectHooksFromNonReactNamespaceOptionName } from './react-hooks-nesting-walker/options';
+import {
+  detectHooksFromNonReactNamespaceOptionName,
+  ignoredFunctionsOptionName
+} from './react-hooks-nesting-walker/options';
 
 export class Rule extends Rules.AbstractRule {
   public static metadata: IRuleMetadata = {
@@ -11,9 +14,13 @@ export class Rule extends Rules.AbstractRule {
     descriptionDetails: 'See https://reactjs.org/docs/hooks-rules.html',
 
     optionsDescription: Utils.dedent`
-      An optional object with the property ${detectHooksFromNonReactNamespaceOptionName}.
-      When set to true, violations will be reported for hooks from namespaces other
+      An optional object with optional properties:
+      - ${detectHooksFromNonReactNamespaceOptionName} When set to true,
+      violations will be reported for hooks from namespaces other
       than the React namespace (e.g. \`MyHooks.useHook\` will be treated as a hook).
+      - ${ignoredFunctionsOptionName} contains a list of function names,
+      that are never treated as hooks.
+      Also effects things from the React namespace, use with care.
     `,
     options: {
       type: 'object',
@@ -21,11 +28,18 @@ export class Rule extends Rules.AbstractRule {
         [detectHooksFromNonReactNamespaceOptionName]: {
           type: 'boolean',
         },
+        [ignoredFunctionsOptionName]: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
       },
     },
     optionExamples: [
       true,
       [true, { [detectHooksFromNonReactNamespaceOptionName]: true }],
+      [true, { [ignoredFunctionsOptionName]: ['useTestHelper'] }],
     ],
 
     hasFix: false,


### PR DESCRIPTION
Adds a new option to configure function names that should not be treated as hooks.
Helpful with functions that have been created before hooks existed,
so al the benefits of the rule apply ignoring those until they have been renamed.

Still untested, wanted to first know if this goes into the right direction before adding extensive testing.

I would like to get first feedback about this idea and the way I attempted to implement it:
- Please let me know if this is something you would like to add.
- Any feedback/ concerns about the place where I'm applying the new option?
- (Does it even make sense to allow ignoring things from the `React` namespace?)