### PR TITLE
Adds illegal anonymous function error msg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'ubuntu-18.04'
 
 steps:
   - task: NodeTool@0

--- a/src/react-hooks-nesting-walker/error-messages.ts
+++ b/src/react-hooks-nesting-walker/error-messages.ts
@@ -17,4 +17,6 @@ export const ERROR_MESSAGES = {
     'A hook cannot be used inside of another function',
   invalidFunctionExpression: 'A hook cannot be used inside of another function',
   hookAfterEarlyReturn: 'A hook should not appear after a return statement',
+  anonymousFunctionIllegalCallback:
+    'Hook is in an anonymous function that is passed to an illegal callback',
 };

--- a/src/react-hooks-nesting-walker/error-messages.ts
+++ b/src/react-hooks-nesting-walker/error-messages.ts
@@ -17,6 +17,5 @@ export const ERROR_MESSAGES = {
     'A hook cannot be used inside of another function',
   invalidFunctionExpression: 'A hook cannot be used inside of another function',
   hookAfterEarlyReturn: 'A hook should not appear after a return statement',
-  anonymousFunctionIllegalCallback:
-    'Hook is in an anonymous function that is passed to an illegal callback',
+  anonymousFunctionIllegalCallback: `Hook is in an anonymous function that is passed to an illegal callback. Legal callbacks identifiers that can receive anonymous functions as arguments are memo and forwardRef`,
 };

--- a/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
+++ b/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
@@ -193,7 +193,11 @@ export class ReactHooksNestingWalker extends RuleWalker {
       /**
        * Detect if the unnamed expression is wrapped in a illegal function call
        */
-      if (isIdentifier((ancestor.parent as CallExpression)?.expression)) {
+      if (
+        isCallExpression(ancestor.parent) &&
+        isIdentifier(ancestor.parent.expression) &&
+        !isComponentOrHookIdentifier(ancestor.parent.expression)
+      ) {
         this.addFailureAtNode(
           hookNode,
           ERROR_MESSAGES.anonymousFunctionIllegalCallback,

--- a/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
+++ b/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
@@ -181,6 +181,21 @@ export class ReactHooksNestingWalker extends RuleWalker {
       }
 
       /**
+       * Detect if the unnamed expression is wrapped in a illegal function call
+       */
+      if (
+        isCallExpression(ancestor.parent) &&
+        isIdentifier(ancestor.parent.expression) &&
+        !isReactComponentDecorator(ancestor.parent.expression)
+      ) {
+        this.addFailureAtNode(
+          hookNode,
+          ERROR_MESSAGES.anonymousFunctionIllegalCallback,
+        );
+        return;
+      }
+
+      /**
        * Allow using hooks when the function is passed to `React.memo` or `React.forwardRef`
        */
       if (

--- a/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
+++ b/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
@@ -193,7 +193,7 @@ export class ReactHooksNestingWalker extends RuleWalker {
       /**
        * Detect if the unnamed expression is wrapped in a illegal function call
        */
-      if (isIdentifier((ancestor.parent as CallExpression).expression)) {
+      if (isIdentifier((ancestor.parent as CallExpression)?.expression)) {
         this.addFailureAtNode(
           hookNode,
           ERROR_MESSAGES.anonymousFunctionIllegalCallback,

--- a/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
+++ b/src/react-hooks-nesting-walker/react-hooks-nesting-walker.ts
@@ -181,27 +181,23 @@ export class ReactHooksNestingWalker extends RuleWalker {
       }
 
       /**
-       * Detect if the unnamed expression is wrapped in a illegal function call
-       */
-      if (
-        isCallExpression(ancestor.parent) &&
-        isIdentifier(ancestor.parent.expression) &&
-        !isReactComponentDecorator(ancestor.parent.expression)
-      ) {
-        this.addFailureAtNode(
-          hookNode,
-          ERROR_MESSAGES.anonymousFunctionIllegalCallback,
-        );
-        return;
-      }
-
-      /**
        * Allow using hooks when the function is passed to `React.memo` or `React.forwardRef`
        */
       if (
         isCallExpression(ancestor.parent) &&
         isReactComponentDecorator(ancestor.parent.expression)
       ) {
+        return;
+      }
+
+      /**
+       * Detect if the unnamed expression is wrapped in a illegal function call
+       */
+      if (isIdentifier((ancestor.parent as CallExpression).expression)) {
+        this.addFailureAtNode(
+          hookNode,
+          ERROR_MESSAGES.anonymousFunctionIllegalCallback,
+        );
         return;
       }
 

--- a/test/tslint-rule/anonymous-function-error.ts.lint
+++ b/test/tslint-rule/anonymous-function-error.ts.lint
@@ -1,6 +1,6 @@
 const IllegalComponent = wrapper(function() {
   useEffect(() => {});
-  ~~~~~~~~~~~~~~~~~~~ [Hook is in an anonymous function that is passed to an illegal callback]
+  ~~~~~~~~~~~~~~~~~~~ [Hook is in an anonymous function that is passed to an illegal callback. Legal callbacks identifiers that can receive anonymous functions as arguments are memo and forwardRef]
 })
 
 const LegalAnonymousComponent = function() {
@@ -17,3 +17,10 @@ const MemoizedComponent = React.memo((props) => {
   const [state, setState] = React.useState(props.initValue);
   return <span>{state}</span>
 })
+
+const Functor = function() {
+  const cb = React.useCallback(() => {
+    const r = React.useRef()
+              ~~~~~~~~~~~~~~ [A hook cannot be used inside of another function]
+  }, [])
+}

--- a/test/tslint-rule/anonymous-function-error.ts.lint
+++ b/test/tslint-rule/anonymous-function-error.ts.lint
@@ -23,4 +23,9 @@ const Functor = function() {
     const r = React.useRef()
               ~~~~~~~~~~~~~~ [A hook cannot be used inside of another function]
   }, [])
+
+  const cb = useCallback(() => {
+    const r = React.useRef()
+              ~~~~~~~~~~~~~~ [A hook cannot be used inside of another function]
+  }, [])
 }

--- a/test/tslint-rule/anonymous-function-error.ts.lint
+++ b/test/tslint-rule/anonymous-function-error.ts.lint
@@ -28,4 +28,10 @@ const Functor = function() {
     const r = React.useRef()
               ~~~~~~~~~~~~~~ [A hook cannot be used inside of another function]
   }, [])
+
+  obj[(props) => { useRef() }] = 123;
+                   ~~~~~~~~           [A hook cannot be used inside of another function]
+
+  new Abc((props) => { useRef() })
+                       ~~~~~~~~    [A hook cannot be used inside of another function] 
 }

--- a/test/tslint-rule/anonymous-function-error.ts.lint
+++ b/test/tslint-rule/anonymous-function-error.ts.lint
@@ -1,0 +1,19 @@
+const IllegalComponent = wrapper(function() {
+  useEffect(() => {});
+  ~~~~~~~~~~~~~~~~~~~ [Hook is in an anonymous function that is passed to an illegal callback]
+})
+
+const LegalAnonymousComponent = function() {
+  useEffect(() => {});
+}
+
+const ForwardedComponent = React.forwardRef(function(props, ref) {
+  useEffect(() => {
+    console.log("I am legal")
+  });
+})
+
+const MemoizedComponent = React.memo((props) => {
+  const [state, setState] = React.useState(props.initValue);
+  return <span>{state}</span>
+})


### PR DESCRIPTION
The only legal scenario for a React component function to be anonymous i.e. unnamed, is when it is passed as a callback to either `React.forwardRef` or `React.memo`.

This can be verified on [eslint's RulesOfHooks](https://github.com/facebook/react/blob/51947a14bb24bd151f76f6fc0acdbbc404de13f7/packages/eslint-plugin-react-hooks/). It uses a different eliminatory logic to rule out violations than this project, so we won't have a 1:1 match in terms of rule verification. But essentially, if a hook's ancestor (AST) node —the function declaration statement— is not in a forwardRef or memo call AND has no valid identifier (conditional stated [here](https://github.com/facebook/react/blob/51947a14bb24bd151f76f6fc0acdbbc404de13f7/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L351)), than it falls back to [this branch](https://github.com/facebook/react/blob/51947a14bb24bd151f76f6fc0acdbbc404de13f7/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L478). 

Current behavior would treat this error as "A hook hook cannot be used inside of another function", which is misleading. 

Resolves #29.
