### PR TITLE
Fixes deprecated ubuntu version used for vmImage value

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'ubuntu-18.04'
 
 steps:
   - task: NodeTool@0


### PR DESCRIPTION
Ubuntu 16.04 is no longer supported for agent pools ran in ADO since Sept 2021. (Quite sometime a pipeline ran in this repo, huh? 😄)

https://github.com/actions/virtual-environments/issues/3287